### PR TITLE
Fixed conference call onhook bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,6 +88,7 @@ class TelephoneSystem:
                             remaining_phone = participants[0]
                             remaining_phone.current_call = None
                             remaining_phone.state = 'offhook'
+                        phone.current_call = None # Clear current_call
                         print(f"{phone.name} hangs up from conference.")
                     else:
                         # Normal call


### PR DESCRIPTION
There was a bug where if a phone hung up from a conference call it would maintain its own current call despite being onhook. Added a phone.current_call = None on line 91 which solved it